### PR TITLE
Fix doc creation helper

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -16,26 +16,31 @@ import {
   onSnapshot,
   Timestamp,
   serverTimestamp,
+  type DocumentReference,
 } from "firebase/firestore";
 
 export const database = {
   // Add a document to a collection
-  add: async (collectionPath: string | string[], data: any) => {
-        try {
-          const pathStr = Array.isArray(collectionPath)
-            ? collectionPath.join("/")
-            : collectionPath;
-          const docRef = await addDoc(collection(db, pathStr), {
-            ...data,
-            createdAt: serverTimestamp(),
-            updatedAt: serverTimestamp(),
-          });
-          return docRef.id;
-        } catch (error) {
-          console.error("Error adding document:", error);
-          throw error;
-        }
-      },
+  add: async (
+    collectionPath: string | string[],
+    data: any,
+  ): Promise<DocumentReference> => {
+    try {
+      const pathStr = Array.isArray(collectionPath)
+        ? collectionPath.join("/")
+        : collectionPath;
+      const docRef = await addDoc(collection(db, pathStr), {
+        ...data,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+      // Return full DocumentReference for consistency across services
+      return docRef;
+    } catch (error) {
+      console.error("Error adding document:", error);
+      throw error;
+    }
+  },
 
       // Set a document with a specific ID
       set: async (


### PR DESCRIPTION
## Summary
- update Firestore helper to return `DocumentReference`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab65aee8c8332865d46d3e0915ac7