### PR TITLE
Fix docId validation in database.set

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -45,23 +45,28 @@ export const database = {
       // Set a document with a specific ID
       set: async (
         collectionPath: string | string[],
-        docId: string,
+        docId: unknown,
         data: any,
         options?: any,
-      ) => {
+      ): Promise<string> => {
         try {
+          if (typeof docId !== "string" || docId.trim() === "") {
+            throw new Error("ID inválido");
+          }
+
           const pathStr = Array.isArray(collectionPath)
             ? collectionPath.join("/")
             : collectionPath;
+
           await setDoc(
-            doc(db, pathStr, docId),
+            doc(db, pathStr, docId as string),
             {
               ...data,
               updatedAt: serverTimestamp(),
             },
             options,
           );
-          return docId;
+          return docId as string;
         } catch (error) {
           console.error("Error setting document:", error);
           throw error;


### PR DESCRIPTION
## Summary
- validate `docId` before calling `setDoc`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687abbce163083328f884538362a54db