### PR TITLE
Allow string paths in localStorage service

### DIFF
--- a/geeklog-mobile/services/database.js
+++ b/geeklog-mobile/services/database.js
@@ -20,7 +20,8 @@ import { db } from "../firebase";
 export const database = {
   async add(path, data) {
     try {
-      const col = collection(db, ...path);
+      const segments = Array.isArray(path) ? path : path.split("/");
+      const col = collection(db, ...segments);
       return await addDoc(col, {
         ...data,
         createdAt: new Date(),
@@ -34,6 +35,7 @@ export const database = {
 
   async set(path, data, opts = {}) {
     try {
+      const segments = Array.isArray(path) ? path : path.split("/");
       const dataToSave = {
         ...data,
         updatedAt: new Date(),
@@ -43,7 +45,7 @@ export const database = {
         dataToSave.createdAt = new Date();
       }
 
-      return await setDoc(doc(db, ...path), dataToSave, opts);
+      return await setDoc(doc(db, ...segments), dataToSave, opts);
     } catch (error) {
       console.error("Database set error:", error);
       throw error;
@@ -52,7 +54,8 @@ export const database = {
 
   async update(path, data) {
     try {
-      return await updateDoc(doc(db, ...path), {
+      const segments = Array.isArray(path) ? path : path.split("/");
+      return await updateDoc(doc(db, ...segments), {
         ...data,
         updatedAt: new Date(),
       });
@@ -64,7 +67,8 @@ export const database = {
 
   async getCollection(path, filters = []) {
     try {
-      let q = collection(db, ...path);
+      const segments = Array.isArray(path) ? path : path.split("/");
+      let q = collection(db, ...segments);
 
       // Apply filters if provided
       if (filters.length > 0) {
@@ -99,7 +103,8 @@ export const database = {
 
   async getDocument(path) {
     try {
-      const snap = await getDoc(doc(db, ...path));
+      const segments = Array.isArray(path) ? path : path.split("/");
+      const snap = await getDoc(doc(db, ...segments));
       return snap.exists() ? { id: snap.id, ...snap.data() } : null;
     } catch (error) {
       console.error("Database getDocument error:", error);
@@ -109,7 +114,8 @@ export const database = {
 
   async delete(path) {
     try {
-      return await deleteDoc(doc(db, ...path));
+      const segments = Array.isArray(path) ? path : path.split("/");
+      return await deleteDoc(doc(db, ...segments));
     } catch (error) {
       console.error("Database delete error:", error);
       throw error;

--- a/src/services/localStorageService.ts
+++ b/src/services/localStorageService.ts
@@ -2,7 +2,7 @@
 
 export const localStorageService = {
   // Get collection from localStorage
-  getCollection: (path: string): any[] => {
+  getCollection: (path: string | string[]): any[] => {
     try {
       const key = Array.isArray(path) ? path.join("/") : path;
       const data = localStorage.getItem(`firebase_${key}`);
@@ -14,7 +14,7 @@ export const localStorageService = {
   },
 
   // Get document from localStorage
-  getDocument: (path: string, docId?: string): any => {
+  getDocument: (path: string | string[], docId?: string): any => {
     try {
       const key = Array.isArray(path) ? path.join("/") : path;
       const fullKey = docId ? `${key}/${docId}` : key;
@@ -37,7 +37,7 @@ export const localStorageService = {
   },
 
   // Add document to localStorage
-  addDocument: (path: string, data: any): string => {
+  addDocument: (path: string | string[], data: any): string => {
     try {
       const key = Array.isArray(path) ? path.join("/") : path;
       const id = Date.now().toString();
@@ -66,7 +66,7 @@ export const localStorageService = {
   },
 
   // Update document in localStorage
-  updateDocument: (path: string, docId: string, data: any): void => {
+  updateDocument: (path: string | string[], docId: string, data: any): void => {
     try {
       const key = Array.isArray(path) ? path.join("/") : path;
       const docKey = `${key}/${docId}`;


### PR DESCRIPTION
## Summary
- accept `string | string[]` for collection helpers
- support string paths in the mobile database service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687abe9f67108332a26cac9c68024255