### PR TITLE
Validate docId before using database.set

### DIFF
--- a/src/services/socialService.ts
+++ b/src/services/socialService.ts
@@ -1,5 +1,5 @@
 import { database } from "./database";
-import { getUserId } from "./utils";
+import { getUserId, ensureValidId } from "./utils";
 import {
   UserProfile,
   UserActivity,
@@ -154,10 +154,12 @@ export async function updateUserProfile(
 export async function followUser(targetUserId: string): Promise<void> {
   try {
     const uid = getUserId();
-    await database.set(["users", uid, "following", targetUserId], {
+    ensureValidId(targetUserId, "ID do usuário alvo ausente ou inválido ao seguir");
+    ensureValidId(uid, "ID do usuário atual ausente ou inválido ao seguir");
+    await database.set(["users", uid, "following"], targetUserId, {
       createdAt: new Date().toISOString(),
     });
-    await database.set(["users", targetUserId, "followers", uid], {
+    await database.set(["users", targetUserId, "followers"], uid, {
       createdAt: new Date().toISOString(),
     });
 

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -44,3 +44,9 @@ export function sanitizeStrings(obj: Record<string, any>): Record<string, any> {
   }
   return result;
 }
+
+export function ensureValidId(id: unknown, message: string): asserts id is string {
+  if (!id || typeof id !== "string" || id.trim() === "") {
+    throw new Error(message);
+  }
+}


### PR DESCRIPTION
## Summary
- add utility to validate Firestore doc IDs
- validate ids on milestone, review and follow services
- fix calls to database.set and update to use explicit doc id

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687bc17d0d7c8332b76edc479d06fbe5