### PR TITLE
Implement profile image upload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import PremiumPending from "./components/PremiumPending";
 import { getMedias } from "./services/mediaService";
 import { getReviews } from "./services/reviewService";
 import { getMilestones } from "./services/milestoneService";
-import { getSettings } from "./services/settingsService";
+import { loadProfile } from "./services/profileService";
 import { AppProvider } from "./context/AppContext";
 import { useAuth } from "./context/AuthContext";
 import { ToastProvider } from "./context/ToastContext";
@@ -142,7 +142,7 @@ function App() {
         getMedias(),
         getReviews(),
         getMilestones(),
-        getSettings(),
+        loadProfile(),
       ]);
       setMediaItems(mItems);
       setReviews(revs);

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -13,6 +13,7 @@ import {
   markAllNotificationsAsRead,
 } from "../services/socialService";
 import { Notification } from "../types/social";
+import { saveProfile as saveProfileService } from "../services/profileService";
 import { saveSettings } from "../services/settingsService";
 import { AchievementNode } from "../types/achievements";
 import MercadoPagoButton from "./MercadoPagoButton";
@@ -30,14 +31,22 @@ const Profile: React.FC = () => {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loadingNotifications, setLoadingNotifications] = useState(false);
 
-  const saveProfile = async (newSettings: typeof settings) => {
-    console.log("💾 Salvando perfil:", newSettings);
-    setSettings(newSettings);
-    if (!user?.uid) {
-      console.error("Usuário não autenticado");
-      return;
-    }
-    await saveSettings(user.uid, newSettings);
+  const handleSaveProfile = async (data: {
+    name: string;
+    bio: string;
+    avatarFile?: File;
+    coverFile?: File;
+  }) => {
+    console.log("💾 Salvando perfil:", data);
+    const result = await saveProfileService(data);
+    const updated = {
+      ...settings,
+      name: data.name,
+      bio: data.bio,
+      avatar: result.avatar ?? settings.avatar,
+      cover: result.cover ?? settings.cover,
+    };
+    setSettings(updated);
     setEditProfile(false);
   };
 
@@ -482,7 +491,7 @@ const Profile: React.FC = () => {
       {editProfile && (
         <EditProfileModal
           profile={settings}
-          onSave={saveProfile}
+          onSave={handleSaveProfile}
           onClose={() => setEditProfile(false)}
         />
       )}

--- a/src/components/modals/EditProfileModal.tsx
+++ b/src/components/modals/EditProfileModal.tsx
@@ -5,9 +5,16 @@ import { useToast } from "../../context/ToastContext";
 import { validateFile, compressImage } from "../../utils/fileValidation";
 import { sanitizeText } from "../../utils/sanitizer";
 
+interface EditProfileData {
+  name: string;
+  bio: string;
+  avatarFile?: File;
+  coverFile?: File;
+}
+
 interface EditProfileModalProps {
   profile: UserSettings;
-  onSave: (settings: UserSettings) => void;
+  onSave: (data: EditProfileData) => void;
   onClose: () => void;
 }
 
@@ -23,6 +30,8 @@ export const EditProfileModal: React.FC<EditProfileModalProps> = ({
     cover: profile?.cover || "",
     bio: profile?.bio || "",
   });
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [coverFile, setCoverFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -50,11 +59,10 @@ export const EditProfileModal: React.FC<EditProfileModalProps> = ({
     try {
       console.log("💾 Salvando perfil no modal:", local);
       onSave({
-        ...profile,
         name: local.name.trim(),
-        avatar: local.avatar || undefined,
-        cover: local.cover || undefined,
         bio: local.bio.trim(),
+        avatarFile: avatarFile || undefined,
+        coverFile: coverFile || undefined,
       });
       showSuccess("Perfil salvo!", "Suas informações foram atualizadas");
     } catch (error) {
@@ -162,6 +170,7 @@ export const EditProfileModal: React.FC<EditProfileModalProps> = ({
                       reader.onload = (ev) => {
                         const result = ev.target?.result as string;
                         setLocal((prev) => ({ ...prev, avatar: result }));
+                        setAvatarFile(processedFile);
                         showSuccess(
                           "Imagem carregada!",
                           "Sua foto de perfil foi atualizada",
@@ -271,6 +280,7 @@ export const EditProfileModal: React.FC<EditProfileModalProps> = ({
                       reader.onload = (ev) => {
                         const result = ev.target?.result as string;
                         setLocal((prev) => ({ ...prev, cover: result }));
+                        setCoverFile(processedFile);
                         showSuccess(
                           "Capa carregada!",
                           "Sua capa de perfil foi atualizada",

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,0 +1,61 @@
+import { database } from './database';
+import { storageClient } from './storageClient';
+import { getUserId, removeUndefinedFields, sanitizeStrings } from './utils';
+import type { UserSettings } from '../App';
+
+export interface SaveProfileParams {
+  name: string;
+  bio?: string;
+  avatarFile?: File;
+  coverFile?: File;
+}
+
+export async function saveProfile({ name, bio, avatarFile, coverFile }: SaveProfileParams): Promise<{ avatar?: string; cover?: string }> {
+  const uid = getUserId();
+  if (!uid) throw new Error('Usuário não autenticado');
+
+  const data: Record<string, any> = removeUndefinedFields(sanitizeStrings({ name, bio }));
+
+  let avatarUrl: string | undefined;
+  let coverUrl: string | undefined;
+
+  if (avatarFile) {
+    avatarUrl = await storageClient.upload('avatar.jpg', avatarFile);
+    data.avatar = avatarUrl;
+  }
+
+  if (coverFile) {
+    coverUrl = await storageClient.upload('cover.jpg', coverFile);
+    data.cover = coverUrl;
+  }
+
+  await database.set(['users'], uid, data, { merge: true });
+  return { avatar: avatarUrl, cover: coverUrl };
+}
+
+export async function loadProfile(userId?: string): Promise<UserSettings | null> {
+  try {
+    const uid = userId || getUserId();
+    if (!uid) return null;
+
+    const userDoc = await database.get(['users'], uid);
+    if (!userDoc.exists()) {
+      return null;
+    }
+
+    const d = userDoc.data();
+    const profile: UserSettings = {
+      name: d.name || 'Usuário',
+      avatar: d.avatar,
+      cover: d.cover,
+      bio: d.bio || '',
+      favorites: d.favorites || { characters: [], games: [], movies: [] },
+      theme: d.theme,
+      defaultLibrarySort: d.defaultLibrarySort || 'updatedAt',
+    };
+    return profile;
+  } catch (error) {
+    console.error('Error loading profile:', error);
+    return null;
+  }
+}

--- a/src/services/storageClient.ts
+++ b/src/services/storageClient.ts
@@ -1,5 +1,6 @@
-import { storage } from '../firebase';
-import { ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage';
+import { storage } from "../firebase";
+import { ref, uploadBytes, getDownloadURL, deleteObject } from "firebase/storage";
+import { getUserId } from "./utils";
 
 class StorageClient {
   private storage = storage;
@@ -48,6 +49,25 @@ class StorageClient {
       console.error("Erro ao deletar arquivo:", e);
       throw e;
     }
+  }
+
+  async upload(relativePath: string, file: File | Blob): Promise<string> {
+    const uid = getUserId();
+    if (!uid) {
+      throw new Error("Usuário não autenticado");
+    }
+    const storageRef = this.createRef(`users/${uid}/${relativePath}`);
+    await this.uploadFile(storageRef, file);
+    return this.getDownloadURL(storageRef);
+  }
+
+  async remove(relativePath: string): Promise<void> {
+    const uid = getUserId();
+    if (!uid) {
+      throw new Error("Usuário não autenticado");
+    }
+    const storageRef = this.createRef(`users/${uid}/${relativePath}`);
+    await this.deleteFile(storageRef);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a `profileService` to handle profile save/load with Firebase Storage
- extend `storageClient` with `upload` and `remove` methods
- update `EditProfileModal` to keep uploaded files and pass them on save
- update `Profile` component to use the new service
- load user profile in `App` via `loadProfile`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6883e1c943708332ae54e2a3b313ffd2